### PR TITLE
Edited get_chr_tables to check bcltools version and to use PATH

### DIFF
--- a/preprocessing/generate_gens_dfs/get_chr_tables.sh
+++ b/preprocessing/generate_gens_dfs/get_chr_tables.sh
@@ -5,13 +5,24 @@ bcf_fn=$1
 chrom=$2
 outdir=$3
 
-mkdir $outdir
+# The -p option will only write the directory if it doesn't exist
+mkdir -p $outdir
 
 echo $1 $2 $3 
 
-sample_list=`~/tools/bcftools-1.5/./bcftools query -l $bcf_fn`
 
-~/tools/bcftools-1.5/./bcftools norm -m - ${bcf_fn} | ~/tools/bcftools-1.5/./bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%TGT]\n' --samples $sample_list > $outdir/${chrom}_prechrtable.txt
+# Check if bcftools is installed, and then check version number
+version=`bcftools -v | head -n1 | cut -d" " -f2`
+req_version=1.5
+
+if [ "$(printf '%s\n' "$req_version" "$version" | sort -r | head -n1)" = "$req_version" ]; then
+	echo "Error: bcftools mush be 1.5 or greater. Current version: $version"
+	exit 1
+fi
+
+sample_list=`bcftools query -l $bcf_fn`
+
+bcftools norm -m - ${bcf_fn} | bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%TGT]\n' --samples $sample_list > $outdir/${chrom}_prechrtable.txt
 
 python fix_chr_tables.py $outdir/${chrom}_prechrtable.txt $chrom $outdir
 


### PR DESCRIPTION
Hey Kathleen,

I noticed in the 'get_chr_tables.sh' script, you were explicitly looking for an installation of bcftools in the home directory. I added a check for the installation version of bcltools on the PATH, which for homebrew install is /usr/local/bin/bcftools. 

Also, the wtc example data 'wtc_grch38_chr1.vcf.gz' does not contain any variants, just a really long header.

Best,
Michael 