### PR TITLE
Additional changes to get_chr_tables.sh, CONFIRMED working with multisample vcf!

### DIFF
--- a/preprocessing/generate_gens_dfs/fix_chr_tables.py
+++ b/preprocessing/generate_gens_dfs/fix_chr_tables.py
@@ -36,7 +36,7 @@ def main():
         vars['chrom'] = vars['chrom'].str[3:]
     vars = vars.query('chrom == @chrom')
     vars_fixed = vars.applymap(fix_multiallelics)
-
+    
     vars_fixed.to_hdf(os.path.join(sys.argv[3], f'chr{chrom}_gens.hdf5'), 'all', complib='blosc')
 
 

--- a/preprocessing/generate_gens_dfs/get_chr_tables.sh
+++ b/preprocessing/generate_gens_dfs/get_chr_tables.sh
@@ -2,7 +2,7 @@
 # required that you have bcftools installed, at least version 1.5
 
 bcf_fn=$1
-chrom=$2
+chrom="${2//chr}" # removes the 'chr', if included
 outdir=$3
 
 # The -p option will only write the directory if it doesn't exist

--- a/preprocessing/generate_gens_dfs/get_chr_tables.sh
+++ b/preprocessing/generate_gens_dfs/get_chr_tables.sh
@@ -1,7 +1,6 @@
 # get chr tables
 # required that you have bcftools installed, at least version 1.5
 
-
 bcf_fn=$1
 chrom=$2
 outdir=$3
@@ -26,7 +25,7 @@ fi
 
 sample_list=`bcftools query -l $bcf_fn`
 
-# Removed --samples, it would not let me run multivariant vcfs
+# Removed --samples in the 'bcftools query' command, it would not let me run with multivariant vcfs.
 bcftools norm -m - ${bcf_fn} | bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%TGT]\n'  > $outdir/${chrom}_prechrtable.txt
 
 # Added $(dirname "$0"), so that is the script is called from another dir, this script can be accessed

--- a/preprocessing/generate_gens_dfs/get_chr_tables.sh
+++ b/preprocessing/generate_gens_dfs/get_chr_tables.sh
@@ -1,6 +1,7 @@
 # get chr tables
 # required that you have bcftools installed, at least version 1.5
 
+
 bcf_fn=$1
 chrom=$2
 outdir=$3
@@ -15,18 +16,23 @@ echo $1 $2 $3
 version=`bcftools -v | head -1 | cut -d ' ' -f2`
 
 req_version=1.5
-
-if [ "$version" == "$req_version" ]; then
+# Checks to see if the version is greater than or equal to 1.5.
+if [ "$(printf '%s\n' "$req_version" "$version" | sort | head -n1)" = "$req_version" ]; then
 	echo "bcftools version $version, running"
 else
-	echo "Error: bcftools must be 1.5. Current version: $version"
+	echo "Error: bcftools must be >=1.5. Current version: $version"
 	exit 1
 fi
 
 sample_list=`bcftools query -l $bcf_fn`
 
-bcftools norm -m - ${bcf_fn} | bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%TGT]\n' --samples $sample_list > $outdir/${chrom}_prechrtable.txt
+# Removed --samples, it would not let me run multivariant vcfs
+bcftools norm -m - ${bcf_fn} | bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%TGT]\n'  > $outdir/${chrom}_prechrtable.txt
 
-python fix_chr_tables.py $outdir/${chrom}_prechrtable.txt $chrom $outdir
+# Added $(dirname "$0"), so that is the script is called from another dir, this script can be accessed
+# Let me know what you think about this. Personally I like to run scripts from the directory where all my files are, or even
+# from a higher directory that contains both my scripts and my input/output files. I got the sample output whether
+# I ran the scrip from 'generate_gens_dfs' or not.
+python $(dirname "$0")/fix_chr_tables.py $outdir/${chrom}_prechrtable.txt $chrom $outdir
 
 rm $outdir/${chrom}_prechrtable.txt


### PR DESCRIPTION
Hi Kathleen,

I am attempting to run through EF with the BEST1 patient samples. I ran get_chr_tables.sh on the multisample vcf and ran into a few issues, specifically with the '--samples' option in 'bcftools query'. I also changed the way the software checks for the users bcftools version, since the newest version is 1.6, it should just verify the version numer is >= 1.5. 

I ran the following commands, both of which produced a file called 'chr11_gens.hdf5' (ok the first command produced a file called 'chrchr11_gens.hdf5', but the other one looked fine):
```
$ bash ExcisionFinder/preprocessing/generate_gens_dfs/get_chr_tables.sh wgs_cohort1_BEST1_chr11.vcf chr11 .
wgs_cohort1_BEST1_chr11.vcf chr11 .
bcftools version 1.6, running
Lines   total/split/realigned/skipped:	558691/21557/0/0
```
```
$ bash get_chr_tables.sh ../../../wgs_cohort1_BEST1_chr11.vcf 11 ../../../
../../../wgs_cohort1_BEST1_chr11.vcf 11 ../../../
bcftools version 1.6, running
Lines   total/split/realigned/skipped:	558691/21557/0/0
```
We should meet before you go off to Japan so I can understand what other files I'll need to create to test the BEST1 loci.

Best,
Michael

PS.

I removed the --sample option below. Here is the erro message I recieved with the original code:
```
[E::hts_open_format] Failed to open file BT_P3_S9.variant
```
Here's the output of 'bcftools query':
```
$ bcftools query -l ../wgs_cohort1_BEST1_chr11.vcf
BT_P1_S2.variant
BT_P3_S9.variant
BT_P6_S7.variant
BT_P7_S6.variant
BT_P8_S3.variant
```
I think something is going wrong with the what bcftools is reading the list view.