### PR TITLE
Mpo get chr tab hotfix

### DIFF
--- a/preprocessing/generate_gens_dfs/get_chr_tables.py
+++ b/preprocessing/generate_gens_dfs/get_chr_tables.py
@@ -9,17 +9,16 @@ Written in Python v 3.6.1.
 Kathleen Keough and Michael Olvera 2017-2018.
 
 Usage:
-	get_chr_tables.py <vcf_file> <locus> <outdir> <name> [-f] [--bed]
+	get_chr_tables.py <vcf_file> <locus> <out> [-f] [--bed]
 
 Arguments:
 	vcf_file           The sample vcf file, separated by chromosome. 
 	locus			   Locus from which to pull variants, in format chromosome:start-stop, or a BED file, 
 					   in which case you must specify --bed
-	outdir             Directory in which to save the output files.
-	name			   The name for the output file.
+	out				   The name for the output file and directory in which to save the output files.
 	-f                 If this option is specified, keeps homozygous variants in output file. 
-	                   Therefore, downstream this will generate both allele-specific and non-
-	                   allele-specific sgRNAs.
+					   Therefore, downstream this will generate both allele-specific and non-
+					   allele-specific sgRNAs.
 	--bed              Indicates that a BED file is being used in place of a locus.
 """
 import pandas as pd
@@ -27,7 +26,7 @@ from docopt import docopt
 import subprocess, os, sys
 import regex as re
 
-__version__='0.0.0'
+__version__='0.0.2'
 
 REQUIRED_BCFTOOLS_VER = 1.5
 
@@ -63,6 +62,8 @@ def fix_multiallelics(cell):
 
 
 def het(genotype):
+	# if genotype == '.':
+	# 	return False
 	gen1, gen2 = re.split('/|\|',genotype)
 	return gen1 != gen2
 
@@ -76,11 +77,19 @@ def filter_hets(gens_df):
 	out = gens_df.query('het')[['chrom', 'pos', 'ref', 'alt']+genotype_cols]
 	return out
 
+def fix_natural_language(name):
+	"""
+	Fixes NaturalNameWarning given by trying to write an hdf5 column name
+	"""
+	for ch in r"\`*{}[]()>#+-.!$":
+		if ch in name:
+			name = name.replace(ch,"_")
+	return name
 
 def main(args):
 	print(args)
 	# Make the outdir
-	os.makedirs(args['<outdir>'], exist_ok=True)
+	os.makedirs(os.path.dirname(args['<out>']), exist_ok=True)
 	vcf_in = args['<vcf_file>']
 	# Check if bcftools is installed, and then check version number
 	check_bcftools()
@@ -90,7 +99,7 @@ def main(args):
 		bed_file = args['<locus>']
 		print(f'Analyzing BED file {bed_file}')
 		bed_df = pd.read_csv(bed_file, sep='\t', header=0, names=['chr','start','stop','locus'])
-		hdf_out = pd.HDFStore(os.path.join(args['<outdir>'],args['<name>'] + '.h5'))
+		hdf_out = pd.HDFStore(args['<out>'] + '.h5')
 		for index, row in bed_df.iterrows():
 			
 			# check whether chromosome in VCF file includes "chr" in chromosome
@@ -109,7 +118,7 @@ def main(args):
 			# removes or adds "chr" based on analyzed VCF
 			chr_name = norm_chr(chrom, chrstart)
 
-			bcl_v=f"bcftools view -r {chr_name}:{str(start)}-{str(stop)} {args['<vcf_file>']}"
+			bcl_v=f"bcftools view -g ^miss -r {chr_name}:{str(start)}-{str(stop)} {args['<vcf_file>']}"
 			
 			# Pipe for bcftools
 			bcl_view = subprocess.Popen(bcl_v,shell=True, stdout=subprocess.PIPE)
@@ -121,7 +130,7 @@ def main(args):
 			# output  
 			raw_dat = bcl_query.communicate()[0].decode("utf-8")
 
-			temp_file_name=f"{args['<outdir>']}/{str(chrom)}_prechrtable.txt"
+			temp_file_name=f"{os.path.dirname(args['<out>'])}/{str(chrom)}_prechrtable.txt"
 			with open(temp_file_name, 'w') as f:
 				f.write(raw_dat)
 				f.close()
@@ -162,17 +171,18 @@ def main(args):
 		# get locus info
 		# check whether chromosome in VCF file includes "chr" in chromosome
 		vcf_chrom = str(subprocess.Popen(f'gzcat {vcf_in} | tail -1 | cut -f1', shell=True))
-		chrom = norm_chr(args['<locus>'].split(':')[0],vcf_chrom.startswith('chr'))
-		start = args['<locus>'].split(':')[1].split('-')[0]
-		stop = args['<locus>'].split(':')[1].split('-')[1]
+		locus = norm_chr(args['<locus>'], vcf_chrom.startswith('chr'))
+		chrom = locus.split(':')[0]
 
 		samples = str(subprocess.Popen(f'bcftools query -l {args["<vcf_file>"]}', shell=True, stdout=subprocess.PIPE).communicate()[0].decode("utf-8")).split('\n')
 		samples = list(filter(None,samples))
+		samples = [ fix_natural_language(name) for name in samples ]
+
 		n_samples = len(samples)
 
 		print(f'There are {n_samples} samples in the provided VCF.')
 
-		bcl_v=f"bcftools view -r {chrom}:{str(start)}-{str(stop)} {args['<vcf_file>']}"
+		bcl_v=f"bcftools view -r {locus} {args['<vcf_file>']}"
 		
 		# Pipe for bcftools
 		bcl_view = subprocess.Popen(bcl_v,shell=True, stdout=subprocess.PIPE)
@@ -184,7 +194,7 @@ def main(args):
 		# output  
 		raw_dat = bcl_query.communicate()[0].decode("utf-8")
 
-		temp_file_name=f"{args['<outdir>']}/{str(chrom)}_prechrtable.txt"
+		temp_file_name=f"{os.path.dirname(args['<out>'])}/{str(chrom)}_prechrtable.txt"
 		with open(temp_file_name, 'w') as f:
 			f.write(raw_dat)
 			f.close()
@@ -211,16 +221,15 @@ def main(args):
 			# gets rid of variants where not at least one ind has a het variant
 			vars_fixed = filter_hets(vars.applymap(fix_multiallelics))
 
-		if args['<name>']:
-			outname = f"{args['<name>']}.hdf5"
-		else:
-			outname = f'chr{chrom}_gens.hdf5'
+		outname = f"{args['<out>']}.hdf5"
 
-		vars_fixed.to_hdf(os.path.join(args['<outdir>'], outname), 'all', format='t', data_columns=True, complib='blosc')
+
+
+		vars_fixed.to_hdf(outname, 'all', format='t', data_columns=True, complib='blosc')
 
 		os.remove(temp_file_name)
 
 
 if __name__ == '__main__':
-	arguments = docopt(__doc__, version='0.1')
+	arguments = docopt(__doc__, version='0.2')
 	main(arguments)

--- a/scripts/CAS_LIST.txt
+++ b/scripts/CAS_LIST.txt
@@ -1,0 +1,28 @@
+## Cas9 object info, stored here. To add new Cas enzymes, append it to 
+## the end of this list, with the following attributes:
+##	<CAS_NAME>	<FORWARD_PAM>	<5'_OR_3'>
+#
+# SpCas9, SpCas9-HF1, eSpCas1.1
+SpCas9	NGG	3'
+# SpCas9 VRER variant
+SpCas9_VRER	NGCG	3'
+# SpCas9 EQR variant
+SpCas9_EQR	NGAG	3'
+# SpCas9 VQR variant 1
+SpCas9_VQR_1	NGA	3'
+# SpCas9 VQR variant 2
+SpCas9_VQR_2	NGNG	3'
+# S. thermophilus Cas9
+StCas9 	NNAGAA	3'
+# S. thermophilus Cas9 2
+StCas9_2 	NGGNG	3'
+# SaCas9
+SaCas9 	NNGRRT	3'
+# SaCas9 KKH variant
+SaCas9_KKH 	NNNRRT	3'
+# nmCas9
+nmCas9 	NNNNGMT	3'
+# campylobacter jejuni Cas9
+cjCas9	NNNNACA	3'
+# Cpf1, PAM 5' of guides
+cpf1	TTTN	5'

--- a/scripts/CAS_LIST.txt
+++ b/scripts/CAS_LIST.txt
@@ -1,7 +1,12 @@
 ## Cas9 object info, stored here. To add new Cas enzymes, append it to 
-## the end of this list, with the following attributes:
-##	<CAS_NAME>	<FORWARD_PAM>	<5'_OR_3'>
-#
+## the end of this list, with the following attributes, seperated by tabs:
+##	<CAS_NAME>	<PAM_SEQ>	<5'_OR_3'_PAM>
+## Any line with a leading hash will not be read.
+## PAM sequences are assumed to be the 5'->3' orientation.
+## 5' or 3' PAMs refer to where the PAM is relative to the sgRNA sequence.
+## 5' PAM: 5'-PAM:sgRNA-3'
+## 3' PAM: 5'-sgRNA:PAM-3'
+#####
 # SpCas9, SpCas9-HF1, eSpCas1.1
 SpCas9	NGG	3'
 # SpCas9 VRER variant

--- a/scripts/cas_object.py
+++ b/scripts/cas_object.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+cas_object.py hold Cas info as part of ExcisionFinder. Written in Python v 3.6.1.
+Kathleen Keough and Michael Olvera 2018.
+
+cas_object.py will do two things:
+	 + hold the Cas9 object info (one object per Cas enzyme) and 
+	 will handle input error checking.
+	 + contain a function to create the objects from an external list
+	 (I was thinking just a text file, so if users want to add more
+	 enzymes in the future they can)
+"""
+import os, sys
+CAS_PATH=os.path.dirname(os.path.realpath(sys.argv[0])) + '/CAS_LIST.txt'
+IUPAC={'Y':'[CT]','R':'[AG]','W':'[AT]',
+	'S':'[GC]','K':'[TG]','M':'[CA]','D':'[AGT]',
+	'V':'[ACG]','H':'[ACT]','B':'[CGT]','N':'[ACGT]',
+	'A':'A','C':'C','G':'G','T':'T'}
+
+
+class Cas(object):
+	"""
+	This is the actual Cas object, holding the enzyme name, primeness, and PAM.
+	The regex version of the PAM can be outputed. The input PAM is assumed to be
+	in the 5'->3' orientation, and can be converted to its reverse orientation.
+
+	"""
+	def __init__(self, name, forwardPam, primeness):
+		self.name = name
+		self.forwardPam = forwardPam
+		self.primeness = primeness
+
+	def __str__(self):
+		return f"Cas Object {self.name},{self.primeness} with PAM:{self.forwardPam}"
+
+
+	def forwardPam_regex(self):
+		"""
+		Returns the regex of the forward PAM. 
+		"""
+		return ''.join([IUPAC[c] for c in self.forwardPam])
+
+	def reversePam_regex(self):
+		"""
+		Returns the regex of the reverse PAM. 
+		"""
+		pam = self.getReversePam()
+		return ''.join([IUPAC[c] for c in pam])
+
+	def getReversePam(self):
+		"""
+		Returns the reverse PAM of the input.
+		"""
+		watson ='ACGTYRSWKMBDHVN'
+		crick = 'TGCARYSWMKVHDBN'
+		return self.forwardPam[::-1].translate(self.forwardPam[::-1].maketrans(watson, crick))
+
+	@property
+	def name(self):
+		return self._name
+
+	@name.setter
+	def name(self, value):
+		self._name = value
+
+	@property
+	def forwardPam(self):
+		return self._forwardPam
+
+	@forwardPam.setter
+	def forwardPam(self, value):
+		value = value.upper()
+		if not all([c in list(IUPAC.keys()) for c in value]):
+			raise ValueError(f"Reported PAM, {value}, contains non-IUPAC characters.")
+		self._forwardPam = value
+
+	@property
+	def reversePam(self):
+		return self.getReversePam()
+
+	@property
+	def primeness(self):
+		return self._primeness
+
+	@primeness.setter
+	def primeness(self, value):
+		if value not in ["3'","5'"]:
+			raise ValueError("must specify 3' or 5'.")
+		self._primeness = value
+
+
+
+def get_cas_enzyme(name, cas_file=CAS_PATH):
+	"""
+	Function to return a specific Cas protein from a master list, in CAS_PATH
+	by default. Since CAS_PATH is a text file, it is easily updated when new Cas
+	enzymes are discovered.
+	"""
+	for line in open(cas_file):
+		if not line.startswith("#"):
+			cas = line.rstrip().split('\t')
+			if cas[0] == name:
+				return Cas(*cas)
+	raise ValueError(f"Cas not found in {cas_file}: {name}") 
+
+
+## Below: for testing, will be removed in next pull or by 4/15/2018
+
+# test1 = get_cas_enzyme('SpCas9')
+# print(test1.name)
+# print(test1.forwardPam)
+# print(test1.forwardPam_regex())
+# print(test1.reversePam)
+# print(test1.reversePam_regex())
+# print(test1.primeness)
+
+# print(len(test1.forwardPam))

--- a/scripts/cas_object.py
+++ b/scripts/cas_object.py
@@ -32,7 +32,7 @@ class Cas(object):
 		self.primeness = primeness
 
 	def __str__(self):
-		return f"Cas Object {self.name},{self.primeness} with PAM:{self.forwardPam}"
+		return f"<Cas Object {self.name}, with {self.primeness} PAM:{self.forwardPam}>"
 
 
 	def forwardPam_regex(self):
@@ -40,14 +40,12 @@ class Cas(object):
 		Returns the regex of the forward PAM. 
 		"""
 		return ''.join([IUPAC[c] for c in self.forwardPam])
-
 	def reversePam_regex(self):
 		"""
 		Returns the regex of the reverse PAM. 
 		"""
 		pam = self.getReversePam()
 		return ''.join([IUPAC[c] for c in pam])
-
 	def getReversePam(self):
 		"""
 		Returns the reverse PAM of the input.
@@ -59,7 +57,6 @@ class Cas(object):
 	@property
 	def name(self):
 		return self._name
-
 	@name.setter
 	def name(self, value):
 		self._name = value
@@ -67,7 +64,6 @@ class Cas(object):
 	@property
 	def forwardPam(self):
 		return self._forwardPam
-
 	@forwardPam.setter
 	def forwardPam(self, value):
 		value = value.upper()
@@ -82,7 +78,6 @@ class Cas(object):
 	@property
 	def primeness(self):
 		return self._primeness
-
 	@primeness.setter
 	def primeness(self, value):
 		if value not in ["3'","5'"]:
@@ -104,11 +99,20 @@ def get_cas_enzyme(name, cas_file=CAS_PATH):
 				return Cas(*cas)
 	raise ValueError(f"Cas not found in {cas_file}: {name}") 
 
+def get_cas_list(cas_file=CAS_PATH):
+	"""
+	Return list of all Cas9 names.
+	"""
+	cas_list = []
+	for line in open(cas_file):
+		if not line.startswith("#"):
+			cas_list.append(line.split('\t')[0])
+	return cas_list 
 
 ## Below: for testing, will be removed in next pull or by 4/15/2018
 
 # test1 = get_cas_enzyme('SpCas9')
-# print(test1.name)
+# print(test1)
 # print(test1.forwardPam)
 # print(test1.forwardPam_regex())
 # print(test1.reversePam)
@@ -116,3 +120,5 @@ def get_cas_enzyme(name, cas_file=CAS_PATH):
 # print(test1.primeness)
 
 # print(len(test1.forwardPam))
+
+# print(get_cas_list())

--- a/scripts/gen_sgRNAs.py
+++ b/scripts/gen_sgRNAs.py
@@ -308,24 +308,12 @@ def get_allele_spec_guides(args, spec_locus=False):
     targ_gens = pd.read_hdf(targ_gens)
 
     verify_hdf_files(gens, targ_gens, chrom, start, stop)
-    # initialize dictionary to save locations of PAM proximal variants
-    pam_prox_vars = {}
 
-    # initialize lists that will eventually become the output dataframe
-    starts = []
-    stops = []
-    refs = []
-    alts = []
-    grna_refs = []
-    grna_alts = []
-    variant_pos_in_guides = []
-    cas_types = []
-    chroms = []
-    variants_positions = []
-    strands = []
-    pam_pos = []
 
-        # get variants within sgRNA region for 3 prime PAMs (guide_length bp upstream of for pos and vice versa)
+    grna_df = pd.DataFrame(columns=['chrom','start','stop','ref','alt','variant_position_in_guide','gRNA_ref','gRNA_alt',
+    'variant_position','strand','cas_type'])
+    ind = 0
+    # get variants within sgRNA region for 3 prime PAMs (guide_length bp upstream of for pos and vice versa)
 
     for cas in CAS_LIST:
             pam_for_pos = np.load(os.path.join(pams_dir, f'chr{chrom}_{cas}_pam_sites_for.npy')).tolist()
@@ -338,6 +326,7 @@ def get_allele_spec_guides(args, spec_locus=False):
                     pam_length = crisprtools.tpp_for[cas][1]
                 else:
                     print('Something is wrong, exiting.') # change this to actual exception
+                    exit(0)
                 cas_prox_vars = []
                 vars_near_pams = targ_gens.query(f'var_near_{cas} == 1')
                 vars_make_pam = targ_gens.query(f'makes_{cas} == 1')
@@ -348,47 +337,26 @@ def get_allele_spec_guides(args, spec_locus=False):
                     proximal_sites_for = list(range(row['pos'], row['pos']+guide_length+1))
                     nearby_for_pams = list(set(proximal_sites_for) & set(pam_for_pos))
                     for pam_site in nearby_for_pams:
-                        start = pam_site - guide_length - 1
-                        starts.append(start)
-                        stops.append(pam_site - 1)
-                        ref_allele = row['ref']
-                        refs.append(ref_allele)
-                        alt_allele = row['alt']
-                        alts.append(alt_allele)
-                        grna_ref_seq, grna_alt_seq = get_alt_seq(chrom, pam_site, var, ref_allele, alt_allele, guide_length, ref_genome, var_type='near_pam')
-                        grna_refs.append(grna_ref_seq)
-                        grna_alts.append(grna_alt_seq)
-                        var_pos = pam_site - var - 1 + pam_length
-                        variant_pos_in_guides.append(var_pos)
-                        cas_types.append(cas)
-                        chroms.append(chrom)
-                        variants_positions.append(var)
-                        strands.append('+')
-                        pam_pos.append(pam_site)
+
+                        grna_ref_seq, grna_alt_seq = get_alt_seq(chrom, pam_site, var, row['ref'], row['alt'], guide_length, ref_genome, var_type='near_pam')
+
+                        grna_df.loc[ind] = ['chr'+str(chrom), (pam_site - guide_length - 1), (pam_site - 1), row['ref'], row['alt'],
+                        (pam_site - var - 1 + pam_length), grna_ref_seq, grna_alt_seq, var, '+', cas]
+                        ind += 1
+
                     proximal_sites_rev = list(range(row['pos']-guide_length,row['pos']))
                     nearby_rev_pams = list(set(proximal_sites_rev) & set(pam_rev_pos))
                     for pam_site in nearby_rev_pams:
-                        var = row['pos']
-                        start = pam_site 
-                        starts.append(start)
-                        stops.append(pam_site + guide_length)
-                        ref_allele = row['ref']
-                        refs.append(ref_allele)
-                        alt_allele = row['alt']
-                        alts.append(alt_allele)
-                        grna_ref_seq, grna_alt_seq = get_alt_seq(chrom, pam_site, var, ref_allele, alt_allele, guide_length, ref_genome, 
+
+                        grna_ref_seq, grna_alt_seq = get_alt_seq(chrom, pam_site, row['pos'], row['ref'], row['alt'], guide_length, ref_genome, 
                             strand='negative', var_type='near_pam')
                         if not args['-c']:
                             grna_ref_seq, grna_alt_seq = make_rev_comp(grna_ref_seq), make_rev_comp(grna_alt_seq)
-                        grna_refs.append(grna_ref_seq)
-                        grna_alts.append(grna_alt_seq)
-                        var_pos = var - pam_site + pam_length - 1
-                        variant_pos_in_guides.append(var_pos)
-                        cas_types.append(cas)
-                        chroms.append(chrom)
-                        variants_positions.append(var)
-                        strands.append('-')
-                        pam_pos.append(pam_site)
+
+                        grna_df.loc[ind] = ['chr'+str(chrom), pam_site, pam_site + guide_length, row['ref'], row['alt'],
+                        var - pam_site + pam_length - 1, grna_ref_seq, grna_alt_seq, var, '-', cas]
+                        ind += 1
+
                 for index, row in vars_destroy_pam.iterrows():
                     var = row['pos']
                     ref = row['ref']
@@ -415,22 +383,12 @@ def get_allele_spec_guides(args, spec_locus=False):
                         alt_allele = alt
                         grna_ref_seq, grna_alt_seq = get_alt_seq(chrom, pam_site, var, ref_allele, alt_allele, guide_length, ref_genome, 
                             var_type='destroys_pam')
-                        start = pam_site - guide_length
-                        starts.append(start)
-                        stops.append(pam_site)
-                        ref_allele = row['ref']
-                        refs.append(ref_allele)
-                        alt_allele = row['alt']
-                        alts.append(alt_allele)
-                        grna_refs.append(grna_ref_seq)
-                        grna_alts.append(grna_alt_seq)
-                        var_pos = pam_site + pam_length - var
-                        variant_pos_in_guides.append(var_pos)
-                        cas_types.append(cas)
-                        chroms.append(chrom)
-                        variants_positions.append(var)
-                        strands.append('+')
+
+                        grna_df.loc[ind] = ['chr'+str(chrom), (pam_site - guide_length), (pam_site), row['ref'], row['alt'],
+                        (pam_site + pam_length - var), grna_ref_seq, grna_alt_seq, var, '+', cas]
+                        ind += 1
                         pam_pos.append(pam_site)
+
                     for pam in lost_pams_rev:
                         pam_site = pam + var - 11
                         ref_allele = ref
@@ -439,24 +397,12 @@ def get_allele_spec_guides(args, spec_locus=False):
                             strand='negative', var_type='destroys_pam')
                         if not args['-c']:
                             grna_ref_seq, grna_alt_seq = make_rev_comp(grna_ref_seq), make_rev_comp(grna_alt_seq)
-                        start = pam_site
-                        starts.append(start)
-                        stop = pam_site + guide_length
-                        stops.append(stop)
-                        refs.append(ref_allele)
-                        alts.append(alt_allele)
-                        grna_refs.append(grna_ref_seq)
-                        grna_alts.append(grna_alt_seq)
-                        var_pos = var - pam_site + pam_length - 1
-                        variant_pos_in_guides.append(var_pos)
-                        cas_types.append(cas)
-                        chroms.append(chrom)
-                        variants_positions.append(var)
-                        strands.append('-')
-                        pam_pos.append(pam_site)
+
+                        grna_df.loc[ind] = ['chr'+str(chrom), (pam_site), (pam_site + guide_length), ref_allele, alt_allele,
+                        (var - pam_site + pam_length - 1), grna_ref_seq, grna_alt_seq, var, '-', cas]
+                        ind += 1
 
                 for index, row in vars_make_pam.iterrows():
-
                     var = row['pos']
                     ref = row['ref']
                     alt = row['alt']
@@ -483,22 +429,11 @@ def get_allele_spec_guides(args, spec_locus=False):
                         alt_allele = alt
                         grna_ref_seq, grna_alt_seq = get_alt_seq(chrom, pam_site, var, ref_allele, alt_allele, guide_length, ref_genome, 
                             var_type='makes_pam')
-                        start = pam_site - guide_length
-                        starts.append(start)
-                        stops.append(pam_site)
-                        ref_allele = row['ref']
-                        refs.append(ref_allele)
-                        alt_allele = row['alt']
-                        alts.append(alt_allele)
-                        grna_refs.append(grna_ref_seq)
-                        grna_alts.append(grna_alt_seq)
-                        var_pos = pam_site + pam_length - var
-                        variant_pos_in_guides.append(var_pos)
-                        cas_types.append(cas)
-                        chroms.append(chrom)
-                        variants_positions.append(var)
-                        strands.append('+')
-                        pam_pos.append(pam_site)
+
+                        grna_df.loc[ind] = ['chr'+str(chrom), (pam_site - guide_length), (pam_site), row['ref'], row['alt'],
+                        (pam_site + pam_length - var), grna_ref_seq, grna_alt_seq, var, '+', cas]
+                        ind += 1
+
                     for pam in made_pams_rev:
                         pam_site = var - 11 + pam
                         ref_allele = ref
@@ -507,33 +442,16 @@ def get_allele_spec_guides(args, spec_locus=False):
                             strand='negative', var_type='makes_pam')
                         if not args['-c']:
                             grna_ref_seq, grna_alt_seq = make_rev_comp(grna_ref_seq), make_rev_comp(grna_alt_seq)
-                        start = pam_site
-                        starts.append(start)
-                        stop = pam_site + guide_length
-                        stops.append(stop)
-                        refs.append(ref_allele)
-                        alts.append(alt_allele)
-                        grna_refs.append(grna_ref_seq)
-                        grna_alts.append(grna_alt_seq)
-                        var_pos = var - pam_site + pam_length
-                        variant_pos_in_guides.append(var_pos)
-                        cas_types.append(cas)
-                        chroms.append(chrom)
-                        variants_positions.append(var)
-                        strands.append('-')
-                        pam_pos.append(pam_site)
+
+                        grna_df.loc[ind] = ['chr'+str(chrom), (pam_site), (pam_site + guide_length), ref_allele, alt_allele,
+                        (var - pam_site + pam_length - 1), grna_ref_seq, grna_alt_seq, var, '-', cas]
+                        ind += 1
 
                
 
-    chroms = list(map(lambda x: 'chr'+str(x),chroms))
+    grna_df = grna_df.query('variant_position_in_guide != 2')
 
-    out = pd.DataFrame({'chrom':chroms,'start':starts, 'stop':stops, 'ref':refs, 'alt':alts,
-        'cas_type':cas_types, 'gRNA_ref':grna_refs, 'gRNA_alt':grna_alts, 'variant_position_in_guide':variant_pos_in_guides,
-        'variant_position':variants_positions, 'strand': strands})
 
-    out = out[['chrom','start','stop','ref','alt','variant_position_in_guide','gRNA_ref','gRNA_alt',
-    'variant_position','strand','cas_type']]
-    out = out.query('variant_position_in_guide != 2')
     # add specificity scores if specified
     if args['--crispor']:
         out = get_crispor_scores(out, out_dir, args['<ref_gen>'])
@@ -545,7 +463,7 @@ def get_allele_spec_guides(args, spec_locus=False):
         gene_vars = gene_vars.rename(index=str, columns={"pos": "variant_position"})
 
         out = out.merge(gene_vars, how='left', on=['chrom','variant_position','ref','alt'])
-    return out
+    return grna_df
 
 
 def get_guides(args, spec_locus=False):
@@ -794,7 +712,7 @@ def get_guides(args, spec_locus=False):
 
 def main(args):
     
-    print(args)
+    #print(args)
 
     if args['--multi']:
         print('Running as multi-locus, assumes BED file given.')
@@ -833,7 +751,8 @@ def main(args):
     else:
         print('Finding allele-specific guides.')
         out = get_allele_spec_guides(args)
-    out['guide_id'] = out.index
+    
+    out['guide_id'] = 'guide' + out.index.astype(str)
     
     if args['<gene_vars>']:
         for i, row in out.iterrows():


### PR DESCRIPTION
Made some fixes to get_chr_tables.py, namely:

- Fixed bug where non-compliant hdf5 characters (ie names containing `.`) were present in vcf sample names.

- Merging outdir and name into a single argument. 

- Passing the locus argument into bcftools in case the user wanted to produce a gens table from an entire chromosome. 