### PR TITLE
Edits to gen_sgRNA, filter for N variants and RNA seq

### DIFF
--- a/scripts/gen_sgRNAs.py
+++ b/scripts/gen_sgRNAs.py
@@ -922,6 +922,12 @@ def main(args):
     if args['-r']:
         out['gRNA_ref'] = out['gRNA_ref'].map(lambda x: x.replace('T','U'))
         out['gRNA_alt'] = out['gRNA_alt'].map(lambda x: x.replace('T','U'))
+
+    if not args['-d']:
+        for i, row in out.iterrows():
+            for col in ['gRNA_ref', 'gRNA_alt']:
+                if row[col] == len(row[col]) * row[col][0]:
+                    out.ix[i,col] = '-' * args['']
     
     # add variant descriptors from 1KGP to assembled guides (optional)
     if args['<gene_vars>']:


### PR DESCRIPTION
Added `-r` and `-d` flags for making RNA sequences for sgRNA outputs and removed sgRNA sequences for guides without PAMs. Also, filter guides for variants that fall in 'N' positions of PAMs.

Still to do, handle other IUPAC letters (etc, 'K') for guides that aren't allele-specific.