### PR TITLE
Extra 'chr' in 5' PAMs

### DIFF
--- a/preprocessing/annotate_variants/annot_variants.py
+++ b/preprocessing/annotate_variants/annot_variants.py
@@ -372,8 +372,8 @@ def main(args):
                 print(current_cas.name)
                 cas_prox_vars = []
                 pam_dict = {}
-                pam_for_pos = np.load(os.path.join(pams_dir, f'chr{chrom}_{cas}_pam_sites_for.npy')).tolist()
-                pam_rev_pos = np.load(os.path.join(pams_dir, f'chr{chrom}_{cas}_pam_sites_rev.npy')).tolist()
+                pam_for_pos = np.load(os.path.join(pams_dir, f'{chrom}_{cas}_pam_sites_for.npy')).tolist()
+                pam_rev_pos = np.load(os.path.join(pams_dir, f'{chrom}_{cas}_pam_sites_rev.npy')).tolist()
                 for pos in pam_for_pos:
                     prox_vars = set(get_range_downstream(pos)) & chr_variants
                     cas_prox_vars.extend(prox_vars)


### PR DESCRIPTION
Minor bug for loading 5' pam_sites.npy. Extra 'chr' in name.