### PR TITLE
Rework of annot_variants. Works with single or multi-locus gens files.

### DIFF
--- a/preprocessing/annotate_variants/annot_variants.py
+++ b/preprocessing/annotate_variants/annot_variants.py
@@ -40,6 +40,18 @@ sys.path.append(cas_obj_path)
 # Import cas_object
 import cas_object as cas_obj
 
+def norm_chr(chrom_str, gens_chrom):
+    """
+    Returns the chromosome string that matches the chromosome annotation of the input gens file
+    """
+    chrom_str = str(chrom_str)
+    if not gens_chrom:
+        return chrom_str.replace('chr','')
+    elif gens_chrom and not chrom_str.startswith('chr'):
+        return 'chr' + chrom_str
+    else:
+        return chrom_str
+
 
 def get_range_upstream(pam_pos, guide_len):
     """
@@ -191,7 +203,8 @@ def main(args):
     else:
         gens = [gens]
 
-    chroms = [ ''.join(['chr',str(ch)]) if not str(ch).startswith('chr') else ch for ch in list(chroms) ]
+    fasta_chrom = list(ref_genome.keys())[0].startswith('chr')
+    chroms = [ norm_chr(ch,fasta_chrom) for ch in list(chroms) ]
 
     # Add check to make sure the correct FASTA file was loaded.
     if set(chroms) != set(list(ref_genome.keys())):

--- a/preprocessing/annotate_variants/annot_variants.py
+++ b/preprocessing/annotate_variants/annot_variants.py
@@ -149,7 +149,11 @@ def get_made_broke_pams(df, chrom, ref_genome):
     :param ref_genome: ref_genome fasta, pyfaidx format.
     :return: dataframe with indicators for whether each variant makes/breaks PAMs, pd df.
     """
+    FULL_CAS_LIST = cas_obj.get_cas_list(os.path.join(cas_obj_path,'CAS_LIST.txt'))
     for cas in cas_list:
+        if cas not in FULL_CAS_LIST:
+            logging.info(f'Skipping {cas}, not in CAS_LIST.txt')
+            continue
         current_cas = cas_obj.get_cas_enzyme(cas, os.path.join(cas_obj_path,'CAS_LIST.txt'))
 
         makes, breaks = zip(*df.apply(lambda row: makes_breaks_pam(current_cas, chrom, row['pos'], row['ref'], row['alt'], ref_genome), axis=1))
@@ -198,15 +202,15 @@ def main(args):
     pam_prox_vars = {}
     # get variants within sgRNA region for 3 prime PAMs (20 bp upstream of for pos and vice versa)
     FULL_CAS_LIST = cas_obj.get_cas_list(os.path.join(cas_obj_path,'CAS_LIST.txt'))
+    for cas in cas_list:
+        if cas not in FULL_CAS_LIST:
+            logging.info(f'Skipping {cas}, not in CAS_LIST.txt')
+            cas_list.remove(cas)
 
     combined_df = []
     for i, chrom in enumerate(chroms):
         chr_variants = set(gens[i]['pos'].tolist())
-
         for cas in cas_list:
-            if cas not in FULL_CAS_LIST:
-                logging.info(f'Skipping {cas}, not in CAS_LIST.txt')
-                continue
             current_cas = cas_obj.get_cas_enzyme(cas, os.path.join(cas_obj_path,'CAS_LIST.txt'))
 
             logging.info(f"Evaluating {current_cas.name} at {chrom}.")

--- a/preprocessing/annotate_variants/annot_variants.py
+++ b/preprocessing/annotate_variants/annot_variants.py
@@ -191,7 +191,7 @@ def main(args):
     else:
         gens = [gens]
 
-    chroms = [ ''.join(['chr',str(ch)]) for ch in list(chroms) if not str(ch).startswith('chr') ]
+    chroms = [ ''.join(['chr',str(ch)]) if not str(ch).startswith('chr') else ch for ch in list(chroms) ]
 
     # Add check to make sure the correct FASTA file was loaded.
     if set(chroms) != set(list(ref_genome.keys())):

--- a/preprocessing/annotate_variants/annot_variants.py
+++ b/preprocessing/annotate_variants/annot_variants.py
@@ -198,15 +198,16 @@ def main(args):
     pam_prox_vars = {}
     # get variants within sgRNA region for 3 prime PAMs (20 bp upstream of for pos and vice versa)
     FULL_CAS_LIST = cas_obj.get_cas_list(os.path.join(cas_obj_path,'CAS_LIST.txt'))
+    for cas in cas_list:
+        if cas not in FULL_CAS_LIST:
+            logging.info(f'Skipping {cas}, not in CAS_LIST.txt')
+            cas_list.remove(cas)
 
     combined_df = []
     for i, chrom in enumerate(chroms):
         chr_variants = set(gens[i]['pos'].tolist())
 
         for cas in cas_list:
-            if cas not in FULL_CAS_LIST:
-                logging.info(f'Skipping {cas}, not in CAS_LIST.txt')
-                continue
             current_cas = cas_obj.get_cas_enzyme(cas, os.path.join(cas_obj_path,'CAS_LIST.txt'))
 
             logging.info(f"Evaluating {current_cas.name} at {chrom}.")

--- a/preprocessing/annotate_variants/annot_variants.py
+++ b/preprocessing/annotate_variants/annot_variants.py
@@ -52,7 +52,7 @@ def get_range_upstream(pam_pos):
 
 def get_range_downstream(pam_pos):
     """
-    Get positions 20 bp upstream, i.e. for forward 3' PAMs or reverse 5' PAMs
+    Get positions 20 bp downstream, i.e. for forward 5' PAMs or reverse 3' PAMs
     :param pam_pos: position of PAM, int.
     :return: sgRNA seed region positions, set of ints.
     """
@@ -305,8 +305,8 @@ def main(args):
                     print(current_cas.name)
                     cas_prox_vars = []
                     pam_dict = {}
-                    pam_for_pos = np.load(os.path.join(pams_dir, f'chr{chrom}_{cas}_pam_sites_for.npy')).tolist()
-                    pam_rev_pos = np.load(os.path.join(pams_dir, f'chr{chrom}_{cas}_pam_sites_rev.npy')).tolist()
+                    pam_for_pos = np.load(os.path.join(pams_dir, f'{chrom}_{cas}_pam_sites_for.npy')).tolist()
+                    pam_rev_pos = np.load(os.path.join(pams_dir, f'{chrom}_{cas}_pam_sites_rev.npy')).tolist()
                     for pos in pam_for_pos:
                         prox_vars = set(get_range_downstream(pos)) & chr_variants
                         cas_prox_vars.extend(prox_vars)

--- a/scripts/cas_object.py
+++ b/scripts/cas_object.py
@@ -12,7 +12,7 @@ cas_object.py will do two things:
 """
 import os, sys
 
-CAS_PATH = f'{sys.path[0]}/CAS_LIST.txt'
+CAS_PATH = f'{os.path.realpath(__file__)}/CAS_LIST.txt'
 
 IUPAC={'Y':'[CT]','R':'[AG]','W':'[AT]',
 	'S':'[GC]','K':'[TG]','M':'[CA]','D':'[AGT]',

--- a/scripts/cas_object.py
+++ b/scripts/cas_object.py
@@ -12,7 +12,7 @@ cas_object.py will do two things:
 """
 import os, sys
 
-CAS_PATH = f'{os.path.realpath(__file__)}/CAS_LIST.txt'
+CAS_PATH = f'{os.path.dirname(__file__)}/CAS_LIST.txt'
 
 IUPAC={'Y':'[CT]','R':'[AG]','W':'[AT]',
 	'S':'[GC]','K':'[TG]','M':'[CA]','D':'[AGT]',


### PR DESCRIPTION
Large changes to annot_variants.py. Before, annot_var only checked the first row's `chrom` value, making it incompatible with multi-locus gens files. It was also not very strick with this, and attempted to use the position value of a variant even if the chromosome was different. 

I implemented annot_var to first gather all chromosomes in a gens file, and if the script detects a multi-locus gens file the gens file dataframe is split by chromosome. The script then iterate through a list of gens dataframes, joining the dataframes at the end. I've tested this script with several cas lists and with both single-locus and multi-locus gens, and the output seems to be fine. You will also get error messages produced for missing pam.npy files or a mising FASTA file. 